### PR TITLE
Fix for Jar not functioning after being build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,31 @@
 
 	</dependencies>
 
+	<build>
+	    <plugins>
+	      <plugin>
+		<groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-shade-plugin</artifactId>
+		<version>3.2.4</version>
+		<executions>
+		  <execution>
+		    <phase>package</phase>
+		    <goals>
+		      <goal>shade</goal>
+		    </goals>
+		    <configuration>
+		      <transformers>
+			<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+			  <mainClass>tobii.TobiiDemo</mainClass>
+			</transformer>
+		      </transformers>
+		    </configuration>
+		  </execution>
+		</executions>
+	      </plugin>
+	    </plugins>
+	 </build>
+	
 	<repositories>
 		<repository>
 			<id>central</id>


### PR DESCRIPTION
I edited the pom.xml so that the jar starts the right main class of the project. I am not sure about the layout, I did it like the documentation below suggests.
Source of the code: https://maven.apache.org/plugins/maven-shade-plugin/examples/executable-jar.html